### PR TITLE
I2C Slave API fails to recognize the master's final NACK

### DIFF
--- a/component/soc/realtek/amebad/fwlib/ram_common/rtl8721d_i2c.c
+++ b/component/soc/realtek/amebad/fwlib/ram_common/rtl8721d_i2c.c
@@ -731,12 +731,12 @@ void I2C_SlaveWrite(I2C_TypeDef *I2Cx, u8* pBuf, u32 len)
 			I2Cx->IC_CLR_RD_REQ;
 		}
 		/* Check I2C TX FIFO status */
-		while((I2C_CheckFlagState(I2Cx, BIT_IC_STATUS_TFNF)) == 0);
+		while(((I2C_CheckFlagState(I2Cx, BIT_IC_STATUS_TFNF)) == 0) && ((I2Cx->IC_RAW_INTR_STAT & BIT_IC_RAW_INTR_STAT_RX_DONE) == 0));
 		
 		I2Cx->IC_DATA_CMD = (*pBuf++);
 	}
-	while((I2C_CheckFlagState(I2Cx, BIT_IC_STATUS_TFE)) == 0);
-}
+	while(((I2C_CheckFlagState(I2Cx, BIT_IC_STATUS_TFE)) == 0) &&((I2Cx->IC_RAW_INTR_STAT & BIT_IC_RAW_INTR_STAT_RX_DONE) == 0));
+	I2Cx->IC_CLR_INTR;
 
 /**
   * @brief  Read data with special length in slave mode through the I2Cx peripheral.

--- a/component/soc/realtek/amebad/fwlib/ram_common/rtl8721d_i2c.c
+++ b/component/soc/realtek/amebad/fwlib/ram_common/rtl8721d_i2c.c
@@ -737,7 +737,7 @@ void I2C_SlaveWrite(I2C_TypeDef *I2Cx, u8* pBuf, u32 len)
 	}
 	while(((I2C_CheckFlagState(I2Cx, BIT_IC_STATUS_TFE)) == 0) &&((I2Cx->IC_RAW_INTR_STAT & BIT_IC_RAW_INTR_STAT_RX_DONE) == 0));
 	I2Cx->IC_CLR_INTR;
-
+}
 /**
   * @brief  Read data with special length in slave mode through the I2Cx peripheral.
   * @param  I2Cx: where I2Cx can be I2C0_DEV.

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_lp/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_lp/Makefile
@@ -13,7 +13,7 @@ OBJS =
 
 # Define the Rules to build the core targets
 all: CORE_TARGETS
-#	make -C asdk flashloader
+	make -C asdk flashloader
 	make -C asdk bootloader
 ifeq ($(CONFIG_USER_CTRL_PS),y)
 	make -C asdk ucps_image2

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_lp/asdk/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_lp/asdk/Makefile
@@ -184,7 +184,7 @@ linker_image2:
 
 linker_loader:
 	@echo "========= linker loader start ========="
-	$(LD) $(LD_ARG) target_loader.axf $(RAM_OBJS_LIST) $(LINK_ROM_LIB) -Wl,--whole-archive -lbootloader_lp -Wl,--no-whole-archive 
+	$(LD) $(LD_ARG) target_loader.axf $(RAM_OBJS_LIST) $(LINK_ROM_LIB) 
 
 	$(MOVE) text.map $(IMAGE_TARGET_FOLDER)/text_loader.map
 	$(MOVE) target_loader.axf $(IMAGE_TARGET_FOLDER)


### PR DESCRIPTION
fix the problem that I2C Slave API fails to recognize the master's final NACK in slave-to-master transmissions